### PR TITLE
Feat: Standalone local debug extension 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 artifacts
 .idea/
+apiserver.local.config/**

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/gofuzz v1.1.0
 	github.com/rancher/kine v0.4.0
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2

--- a/internal/sample-apiserver/pkg/cmd/server/ext.go
+++ b/internal/sample-apiserver/pkg/cmd/server/ext.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"github.com/spf13/pflag"
 	"k8s.io/apiserver/pkg/endpoints/openapi"
 	pkgserver "k8s.io/apiserver/pkg/server"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
@@ -27,6 +28,7 @@ var (
 	EtcdPath              string
 	RecommendedConfigFns  []func(*pkgserver.RecommendedConfig) *pkgserver.RecommendedConfig
 	ServerOptionsFns      []func(server *ServerOptions) *ServerOptions
+	FlagsFns              []func(fs *pflag.FlagSet) *pflag.FlagSet
 	NewCommandStartServer = NewCommandStartWardleServer
 )
 
@@ -44,6 +46,13 @@ func ApplyRecommendedConfigFns(in *pkgserver.RecommendedConfig) *pkgserver.Recom
 		in = RecommendedConfigFns[i](in)
 	}
 	return in
+}
+
+func ApplyFlagsFns(fs *pflag.FlagSet) *pflag.FlagSet {
+	for i := range FlagsFns {
+		fs = FlagsFns[i](fs)
+	}
+	return fs
 }
 
 func SetOpenAPIDefinitions(name, version string, defs openapicommon.GetOpenAPIDefinitions) {

--- a/internal/sample-apiserver/pkg/cmd/server/start.go
+++ b/internal/sample-apiserver/pkg/cmd/server/start.go
@@ -164,7 +164,9 @@ func (o WardleServerOptions) RunWardleServer(stopCh <-chan struct{}) error {
 	}
 
 	server.GenericAPIServer.AddPostStartHookOrDie("start-sample-server-informers", func(context genericapiserver.PostStartHookContext) error {
-		config.GenericConfig.SharedInformerFactory.Start(context.StopCh)
+		if config.GenericConfig.SharedInformerFactory != nil {
+			config.GenericConfig.SharedInformerFactory.Start(context.StopCh)
+		}
 		return nil
 	})
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -86,6 +86,7 @@ func (a *Server) Build() (*Command, error) {
 	}
 	o := server.NewWardleServerOptions(os.Stdout, os.Stderr, a.orderedGroupVersions...)
 	cmd := server.NewCommandStartServer(o, genericapiserver.SetupSignalHandler())
+	server.ApplyFlagsFns(cmd.Flags())
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	return cmd, nil
 }

--- a/pkg/builder/builder_auth.go
+++ b/pkg/builder/builder_auth.go
@@ -1,6 +1,10 @@
 package builder
 
-import "sigs.k8s.io/apiserver-runtime/internal/sample-apiserver/pkg/cmd/server"
+import (
+	"github.com/spf13/pflag"
+	"k8s.io/klog"
+	"sigs.k8s.io/apiserver-runtime/internal/sample-apiserver/pkg/cmd/server"
+)
 
 // SetDelegateAuthOptional makes delegated authentication and authorization optional, otherwise
 // the apiserver won't failing upon missing delegated auth configurations.
@@ -18,6 +22,35 @@ func (a *Server) DisableAuthorization() *Server {
 	server.ServerOptionsFns = append(server.ServerOptionsFns, func(o *ServerOptions) *ServerOptions {
 		o.RecommendedOptions.Authorization = nil
 		return o
+	})
+	return a
+}
+
+var enablesLocalStandaloneDebugging bool
+
+// WithLocalDebugExtension adds an optional local-debug mode to the apiserver so that it can be tested
+// locally without involving a complete kubernetes cluster. A flag named "--standalone-debug-mode" will
+// also be added the binary which forcily requires "--bind-address" to be "127.0.0.1" in order to avoid
+// security issues.
+func (a *Server) WithLocalDebugExtension() *Server {
+	server.ServerOptionsFns = append(server.ServerOptionsFns, func(options *ServerOptions) *ServerOptions {
+		secureBindingAddr := options.RecommendedOptions.SecureServing.BindAddress.String()
+		if enablesLocalStandaloneDebugging {
+			if secureBindingAddr != "127.0.0.1" {
+				klog.Fatal(`the binding address must be "127.0.0.1" if --standalone-debug-mode is set`)
+			}
+			options.RecommendedOptions.Authorization = nil
+			options.RecommendedOptions.CoreAPI = nil
+			options.RecommendedOptions.Admission = nil
+		}
+		return options
+	})
+	server.FlagsFns = append(server.FlagsFns, func(fs *pflag.FlagSet) *pflag.FlagSet {
+		fs.BoolVar(&enablesLocalStandaloneDebugging, "standalone-debug-mode", false,
+			"Under the local-debug mode the apiserver will allow all access to its resources without "+
+				"authorizing the requests, this flag is only intended for debugging in your workstation "+
+				"and the apiserver will be crashing if its binding address is not 127.0.0.1.")
+		return fs
 	})
 	return a
 }

--- a/pkg/builder/builder_general.go
+++ b/pkg/builder/builder_general.go
@@ -18,6 +18,7 @@ func (a *Server) WithServerFns(fns ...func(server *GenericAPIServer) *GenericAPI
 	return a
 }
 
+// WithFlagFns sets functions to customize the flags for the compiled binary.
 func (a *Server) WithFlagFns(fns ...func(set *pflag.FlagSet) *pflag.FlagSet) *Server {
 	server.FlagsFns = append(server.FlagsFns, fns...)
 	return a

--- a/pkg/builder/builder_general.go
+++ b/pkg/builder/builder_general.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"github.com/spf13/pflag"
 	"sigs.k8s.io/apiserver-runtime/internal/sample-apiserver/pkg/apiserver"
 	"sigs.k8s.io/apiserver-runtime/internal/sample-apiserver/pkg/cmd/server"
 )
@@ -14,5 +15,10 @@ func (a *Server) WithOptionsFns(fns ...func(*ServerOptions) *ServerOptions) *Ser
 // WithServerFns sets functions to customize the GenericAPIServer
 func (a *Server) WithServerFns(fns ...func(server *GenericAPIServer) *GenericAPIServer) *Server {
 	apiserver.GenericAPIServerFns = append(apiserver.GenericAPIServerFns, fns...)
+	return a
+}
+
+func (a *Server) WithFlagFns(fns ...func(set *pflag.FlagSet) *pflag.FlagSet) *Server {
+	server.FlagsFns = append(server.FlagsFns, fns...)
 	return a
 }


### PR DESCRIPTION
users can opt-in to this standalone running extension to run the apiserver by setting `--standalone-debug-mode` in the flags which allows direct access to its resources e.g. by `curl -k https://127.0.0.1:443/apis/...`. (note that this extension requires explicitly setting `--bind-address` to 127.0.0.1 to keep the users aware of the security issues exposed by this flag.) 

the testing environment utilities provided by controller-runtime allows us to start a local kube-apiserver and install CRDs to it upon running test suites. we need similar testing environment for AA servers and the extension will be helpful for starting a local testing environment w/o involving a real kubernetes cluster. 