### PR TITLE
Merge "SetDelegateAuthOptional" into "WithLocalDebugExtension"

### DIFF
--- a/internal/example/cmd/main.go
+++ b/internal/example/cmd/main.go
@@ -28,7 +28,6 @@ func main() {
 	var _ resource.Object = &v1beta1.ExampleResource{}
 
 	cmd, err := builder.APIServer.
-		SetDelegateAuthOptional().
 		// v1alpha1 will be the storage version because it was registered first
 		WithResource(&v1alpha1.ExampleResource{}).
 		// v1beta1 objects will be converted to v1alpha1 versions before being stored
@@ -36,6 +35,8 @@ func main() {
 		// OpenAPI definitions are optional for an apiserver, unless you need the openapi
 		// functionalities for some cases.
 		// WithOpenAPIDefinitions("example", "v0.0.0", openapi.GetOpenAPIDefinitions).
+		// Allows you running unsecured apiserver locally.
+		WithLocalDebugExtension().
 		Build()
 	if err != nil {
 		panic(err)

--- a/pkg/builder/builder_auth.go
+++ b/pkg/builder/builder_auth.go
@@ -6,17 +6,6 @@ import (
 	"sigs.k8s.io/apiserver-runtime/internal/sample-apiserver/pkg/cmd/server"
 )
 
-// SetDelegateAuthOptional makes delegated authentication and authorization optional, otherwise
-// the apiserver won't failing upon missing delegated auth configurations.
-func (a *Server) SetDelegateAuthOptional() *Server {
-	server.ServerOptionsFns = append(server.ServerOptionsFns, func(o *ServerOptions) *ServerOptions {
-		o.RecommendedOptions.Authentication.RemoteKubeConfigFileOptional = true
-		o.RecommendedOptions.Authorization.RemoteKubeConfigFileOptional = true
-		return o
-	})
-	return a
-}
-
 // DisableAuthorization disables delegated authentication and authorization
 func (a *Server) DisableAuthorization() *Server {
 	server.ServerOptionsFns = append(server.ServerOptionsFns, func(o *ServerOptions) *ServerOptions {
@@ -51,6 +40,11 @@ func (a *Server) WithLocalDebugExtension() *Server {
 				"authorizing the requests, this flag is only intended for debugging in your workstation "+
 				"and the apiserver will be crashing if its binding address is not 127.0.0.1.")
 		return fs
+	})
+	server.ServerOptionsFns = append(server.ServerOptionsFns, func(o *ServerOptions) *ServerOptions {
+		o.RecommendedOptions.Authentication.RemoteKubeConfigFileOptional = true
+		o.RecommendedOptions.Authorization.RemoteKubeConfigFileOptional = true
+		return o
 	})
 	return a
 }


### PR DESCRIPTION
we dont need "SetDelegateAuthOptional" any more b/c it's originally intended for local running an unsecured apiserver. merging this into "WithLocalDebugExtension"..