### PR TITLE
Feat: Opt out from etcd healthcheck so that apiserver can run completely w/o etcd

### DIFF
--- a/internal/sample-apiserver/pkg/cmd/server/start.go
+++ b/internal/sample-apiserver/pkg/cmd/server/start.go
@@ -115,7 +115,11 @@ func (o *WardleServerOptions) Config() (*apiserver.Config, error) {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 
-	o.RecommendedOptions.Etcd.StorageConfig.Paging = utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)
+	// change: allow etcd options to be nil
+	// TODO: this should be reverted after rebasing sample-apiserver onto https://github.com/kubernetes/kubernetes/pull/101106
+	if o.RecommendedOptions.Etcd != nil {
+		o.RecommendedOptions.Etcd.StorageConfig.Paging = utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)
+	}
 
 	// change: apiserver-runtime
 	// ExtraAdmissionInitializers set through ApplyServerOptionsFns by appending to ServerOptionsFns

--- a/pkg/builder/builder_misc.go
+++ b/pkg/builder/builder_misc.go
@@ -55,3 +55,11 @@ func (a *Server) ExposeLoopbackAuthorizer() *Server {
 		return s
 	})
 }
+
+// WithoutEtcd removes etcd related settings from apiserver.
+func (a *Server) WithoutEtcd() *Server {
+	return a.WithOptionsFns(func(o *ServerOptions) *ServerOptions {
+		o.RecommendedOptions.Etcd = nil
+		return o
+	})
+}


### PR DESCRIPTION
ref: #44 
ref: https://github.com/kubernetes-sigs/apiserver-builder-alpha/issues/583