### PR TITLE
apiserver-runtime-gen easier to use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/mod v0.4.2
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/apiserver v0.21.2

--- a/pkg/builder/doc.go
+++ b/pkg/builder/doc.go
@@ -43,7 +43,7 @@ limitations under the License.
 // Install the code generators (from your module):
 //
 //    $ go get sigs.k8s.io/apiserver-runtime/tools/apiserver-runtime-gen
-//    $ apiserver-runtime-gen --install
+//    $ apiserver-runtime-gen --install-generators
 //
 // Add the code generation tag to you main package:
 //


### PR DESCRIPTION
1. `--install` is not exist, it should be `--install-generators` here.
2. if not go file in current dir. `go mod why` output nothing. use modfile replace it.