### PR TITLE
bugfix: copy from non-storage version instead of storage version

### DIFF
--- a/pkg/builder/resource/register.go
+++ b/pkg/builder/resource/register.go
@@ -40,7 +40,7 @@ func AddToScheme(objs ...Object) func(s *runtime.Scheme) error {
 					return err
 				}
 				if err := s.AddConversionFunc(storageVersionObj, obj, func(from, to interface{}, _ conversion.Scope) error {
-					return from.(MultiVersionObject).ConvertFromStorageVersion(to.(runtime.Object))
+					return to.(MultiVersionObject).ConvertFromStorageVersion(from.(runtime.Object))
 				}); err != nil {
 					return err
 				}


### PR DESCRIPTION
In that duty line (43), parameter 'from' is 'storageVersionObj' which is storage version  object reference, it needn't to implement interface MultiVersionObject, so it can't be convert to that interface anyway. 

It looks like line 43 contains a bug: 'from' and 'to' should be switched positions. Kindly review and confirm, thanks.

BTW, I use the fix to replace the official library locally to run my aggregated server, success. So most likely it is a bug.